### PR TITLE
Filters + history

### DIFF
--- a/src/_includes/partials/results-list.njk
+++ b/src/_includes/partials/results-list.njk
@@ -1,4 +1,5 @@
 <h2 class="mb-1">Collection Results</h2>
+<p class="results-heading">{{ colllist.items.length }} results</p>
 <ul class="results-list">
   {% for item in colllist.items %}
   <li data-collid="{{ item.collid }}">

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -195,4 +195,16 @@ findCollectionEl.addEventListener('keyup', (event) => {
 // TODO - setup handlers for filter de/selection and weep
 // for jQuery delegation
 
-doSearch(null);
+let initialQuery = null;
+let params = new URLSearchParams(location.search);
+if ( params.has('byText') ) {
+  initialQuery = params.get('byText');
+  findCollectionEl.value = initialQuery;
+  params.delete('byText');
+}
+params.keys().forEach((param) => {
+  let key = param.replace('by', '');
+  activeFilters[key] = params.getAll(param);
+})
+
+doSearch(initialQuery, false);

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -18,13 +18,13 @@ let sidePanelEl = document.querySelector('.side-panel');
 let availableFiltersEl = document.querySelector('#available-filters');
 let currentFilterPanelEl = document.querySelector('#current-filters');
 const findCollectionEl = document.querySelector('#find-collection');
+const resultsHeadingEl = document.querySelector('.results-heading');
 
 sidePanelEl.addEventListener('change', (event) => {
   if ( event.target.type != 'checkbox' ) { return ; }
   let input = event.target;
   let value = input.value;
-  let key = input.name.replace('filter-', '');
-  console.log("-- change", input);
+  let key = input.dataset.key;
   if ( ! activeFilters[key] ) { activeFilters[key] = []; }
   if ( input.dataset.action == 'remove' ) {
     activeFilters[key] = activeFilters[key].filter(v => v != value);
@@ -42,10 +42,12 @@ const buildFilterItem = function(key, term, count, idx, checked=false) {
   let inputEl = item.querySelector('input');
   let labelEl = item.querySelector('label');
   let action = checked ? 'remove' : 'add';
-  inputEl.id = `${action}-${key}-${idx}`;
+  let slug = key.toLowerCase().replace(/[^\w+]/g, '-');
+  inputEl.id = `${action}-${slug}-${idx}`;
   inputEl.value = term;
-  inputEl.name = `filter-${key}`;
+  inputEl.name = `filter-${slug}`;
   inputEl.checked = checked;
+  inputEl.dataset.key = key;
   if ( checked ) {
     inputEl.dataset.action = 'remove';
     labelEl.innerHTML = `<span class="seperator">${key}</span> ${term}`;
@@ -57,7 +59,7 @@ const buildFilterItem = function(key, term, count, idx, checked=false) {
   return item;
 }
 
-const updateactiveFilterStyles = function(collids) {
+const updateActiveFilterStyles = function(collids) {
   if ( collids === undefined ) {
     styles.cssRules[0].selectorText = `li[data-collid]`;
   } else {
@@ -107,6 +109,11 @@ const updateAvailableFilters = function(filters) {
           panel.querySelector('summary').innerHTML = `Filter by ${key}`;
           availableFiltersEl.append(panel);
           panel = availableFiltersEl.querySelector(`details[data-key="${key}"]`);
+          if ( key == 'Format' || key == 'Access' ) {
+            panel.open = true;
+          } else if ( activeFilters[key] !== undefined ) {
+            panel.open = true;
+          }
         }
         let item = buildFilterItem(key, term, filters[key][term], termIdx, false);
         panel.querySelector('.filter-item--list').append(item);
@@ -115,17 +122,65 @@ const updateAvailableFilters = function(filters) {
   })
 }
 
-const doSearch = async function(value) {
+const updateResultsHeading = function(total) {
+  let suffix = ( total == 1 ) ? 'result' : 'results';
+  resultsHeadingEl.innerHTML = `${total} ${suffix}`;
+}
+
+const updateHistory = function() {
+  const params = new URLSearchParams();
+  if ( findCollectionEl.value ) {
+    params.set('byText', findCollectionEl.value);
+  }
+  Object.keys(activeFilters).forEach((key) => {
+    activeFilters[key].forEach((term) => {
+      params.append(`by${key}`, term);
+    })
+  })
+  if ( params.toString() != '' || location.search != '' ) {
+    history.pushState({ Text: findCollectionEl.value, filters: activeFilters}, "", `${location.pathname}?${params.toString()}`);
+  }
+}
+
+const clearActiveFilters = function() {
+  // reset active filters
+  Object.keys(activeFilters).forEach((key) => {
+    delete activeFilters[key];
+  })
+}
+
+window.addEventListener('popstate', (event) => {
+  let q = null;
+  clearActiveFilters();
+  if ( event.state && event.state.Text !== undefined ) {
+    q = event.state.Text;
+    Object.keys(event.state.filters).forEach((key) => {
+      activeFilters[key] = event.state.filters[key];
+    })
+  }
+  doSearch(q, false);
+})
+
+const doSearch = async function(value, doUpdateHistory=true) {
   if ( ! value ) { value = null; }
   const search = await pagefind.search(value, {
     filters: activeFilters,
   })
   const results = await Promise.all(search.results.map(r => r.data()));
-  updateactiveFilterStyles(results.map(r => r.meta.collid));
+  updateActiveFilterStyles(results.map(r => r.meta.collid));
   updateAvailableFilters(search.filters);
   updateCurrentFilters(search.filters);
+  updateResultsHeading(results.length);
+  if ( doUpdateHistory ) {
+    updateHistory();
+  }
   // console.log("-- doSearch fin", value, activeFilters, results.map(r => r.meta.collid));
 }
+
+currentFilterPanelEl.querySelector('button.clear-all-btn').addEventListener('click', (event) => {
+  clearActiveFilters();
+  doSearch(null);
+});
 
 pagefind.init();
 


### PR DESCRIPTION
Implements more of the filter functionality:

* creates a `slug` for input names and ids to resolve ARC errors
* wires the "clear all" button
* sets the Format and Availability panels to open
* sets any panel that has active items to open after a search

Adds history/context support:

* updates the results heading
* updates the history with text and filters
* initializes the app based on incoming URL parameters
